### PR TITLE
Page data refactor

### DIFF
--- a/pmp/app-elements/partners/partner-details.html
+++ b/pmp/app-elements/partners/partner-details.html
@@ -17,9 +17,6 @@
 <link rel="import" href="../../../styles/shared-styles.html">
 <link rel="import" href="../../../styles/risk-rating-styles.html">
 
-<!-- TODO: move partner-data into partners folder -->
-<link rel="import" href="../partner-data/partner-data.html">
-
 <link rel="import" href="assessments-items.html">
 <link rel="import" href="staff-members.html">
 <link rel="import" href="bank-information.html">
@@ -56,8 +53,6 @@
       }
 
     </style>
-
-    <partner-data partner-id="[[partnerId]]" partner="{{partner}}"></partner-data>
 
     <!-- main page content start -->
     <div id="pageContent">
@@ -249,14 +244,6 @@
         ],
 
         properties: {
-          partnerId: {
-            type: Number,
-            notify: true
-          },
-          partnerName: {
-            type: String,
-            notify: true
-          },
           partner: {
             type: Object,
             value: {},
@@ -353,15 +340,7 @@
           ]);
         },
 
-        _partnerIdChanged: function(id) {
-          this.set('partnerId', parseInt(id, 10));
-        },
-
         _partnerChanged: function(partner) {
-//          console.log(partner);
-          if (partner && partner.name) {
-            this.set('partnerName', partner.name);
-          }
           // set core_values_assessment files
           if (partner
               && typeof partner.core_values_assessment === 'string'

--- a/pmp/pages/page-partners.html
+++ b/pmp/pages/page-partners.html
@@ -110,10 +110,6 @@
 
         partnerPage: {
           type: String,
-        },
-
-        partnerName: {
-          type: String
         }
 
       },

--- a/pmp/pages/page-partners.html
+++ b/pmp/pages/page-partners.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../../bower_components/paper-tabs/paper-tabs.html">
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
 
+<link rel="import" href="../app-elements/partner-data/partner-data.html">
 <link rel="import" href="../app-elements/page-header/page-header.html">
 <link rel="import" href="../app-elements/partners/partners-list.html">
 <link rel="import" href="../app-elements/partners/partner-overview.html">
@@ -49,7 +50,7 @@
       <div class="page-top-content" hidden$="{{!tabsActive}}">
         <div class="top-content">
           <div class="top-content-row title-row">
-            <h1 main-title>[[partnerName]]</h1>
+            <h1 main-title>[[partner.name]]</h1>
             <div class="top-content-actions-wrapper">
               <div class="top-content-action">
                 <paper-button>
@@ -88,10 +89,10 @@
           <partners-list id="list"></partners-list>
         </div>
         <div class="page" name="overview">
-          <partner-overview partner-id="[[routeData.id]]" partner-name="{{partnerName}}"></partner-overview>
+          <partner-overview partner="[[partner]]"></partner-overview>
         </div>
         <div class="page" name="details">
-          <partner-details partner-id="[[routeData.id]]" partner-name="{{partnerName}}"></partner-details>
+          <partner-details partner="[[partner]]"></partner-details>
         </div>
       </iron-pages>
 


### PR DESCRIPTION
@adi130987 Previously you were stamping a `partner-data` in both details and overview. This is just a small tweak to instead stamp one `partner-data` in `page-partners` and bind the partner down into details and overview. And I removed the relevant redundancies that followed the change.