### PR TITLE
fix(government-details): Refreshing details/add new page now works

### DIFF
--- a/pmp/app-behaviors/common-general-behavior.html
+++ b/pmp/app-behaviors/common-general-behavior.html
@@ -61,7 +61,7 @@
     },
 
     getFileNameFromURL: function(url) {
-      return _.last(url.split('/')).split('?').shift();
+      return _.head(url.split('?')).split('/').pop();
     },
 
     /**

--- a/pmp/app-elements/governments/government-details.html
+++ b/pmp/app-elements/governments/government-details.html
@@ -131,6 +131,7 @@
       ],
       observers: [
         '_getYears(countryProgrammeDropdownData, intervention.country_programme)',
+         '_init(active)'
       ],
       properties: {
         intervention: {
@@ -158,6 +159,13 @@
           notify: true
         },
       },
+      _init : function(active) {
+        if(active) {
+          if (_.isEmpty(this.intervention)) {
+            this.fire('details-refresh');
+          }
+        }
+      },
       _getYears: function () {
         var cpObject = _.find(this.countryProgrammeDropdownData, {value: this.intervention.country_programme});
         if (!_.isEmpty(cpObject)) {
@@ -176,7 +184,7 @@
         }
       },
       _addNewResult: function () {
-        var intervention = this.intervention.id || "";
+        var intervention = _.get(this.intervention,'id') || "";
         var newResult = {
           "intervention": intervention,
           "result": "",

--- a/pmp/app-elements/governments/government-details.html
+++ b/pmp/app-elements/governments/government-details.html
@@ -215,12 +215,12 @@
         // validate partner
         if(!this.intervention.partner){
           this.$$("#partner").invalid = true;
-          valid= false;
+          valid = false;
         }
         //validate country programme
         if(!this.intervention.country_programme){
           this.$$("#country_programme").invalid = true;
-          valid= false;
+          valid = false;
         }
         var resultsValid= this.$.governmentResults._fieldsAreValid('result','year','planned_amount','planned_visits');
 				if(!resultsValid){

--- a/pmp/pages/page-governments.html
+++ b/pmp/pages/page-governments.html
@@ -125,7 +125,8 @@
         </div>
         <div class="page" name="details">
           <government-details id="details"
-                              new-intervention-model="[[newInterventionModel]]"
+                              active="[[newInterventionActive]]"
+]                             on-details-refresh="_goToNewGovernmentPage"
                               intervention="[[intervention]]"
                               edit-mode="[[_hasEditPermissions(permissions)]]"
                               on-save-intervention="_saveIntervention"></government-details>


### PR DESCRIPTION
You can now refresh details/add new government in simple page without errors.