### PR TITLE
fix(filename display): attachment file names parser fix

### DIFF
--- a/pmp/app-behaviors/common-general-behavior.html
+++ b/pmp/app-behaviors/common-general-behavior.html
@@ -61,7 +61,7 @@
     },
 
     getFileNameFromURL: function(url) {
-      return _.last(url.split('/')).split('?').shift();
+      return _.head(url.split('?')).split('/').pop();
     },
 
     /**


### PR DESCRIPTION
Parse fix for attachment filename displayed.