### PR TITLE
Core values assesments: show field for other partners also

### DIFF
--- a/pmp/app-elements/partners/partner-details.html
+++ b/pmp/app-elements/partners/partner-details.html
@@ -298,7 +298,8 @@
          * and cso_type is 'National'
          */
         _showCoreValueAssessment: function(partnerType, csoType) {
-          if (partnerType === 'Civil Society Organization' && csoType === 'National') {
+          if (partnerType === 'Civil Society Organization' &&
+          (['National', 'Academic Institution', 'Community Based Organization'].indexOf(csoType) > -1)) {
             return true;
           }
           return false;


### PR DESCRIPTION
- Show  field Core Values Assesments for partners with csoType equal to Academic Institution or Community Based Organization also

- connects unicef/etools-issues#157