### PR TITLE
Intervention details Edge fixes

### DIFF
--- a/pmp/app-elements/interventions/intervention-details.html
+++ b/pmp/app-elements/interventions/intervention-details.html
@@ -472,14 +472,15 @@
         },
 
         _selectedPartnerIdChanged: function(id, oldId) {
+          if (typeof oldId === 'number'
+              && id !== oldId
+              && !this.agreement) { //Prevent reset on changes caused by initialization of the fields
 
-          if (typeof oldId === 'number' && id !== oldId) {
             // reset partner focal points options and value
             this.set('intervention.partner_focal_points', []);
             this.set('partnerStaffMembers', []);
           }
         },
-
         /**
          * When an agreement is selected then check it's type and update document types dropdown
          */

--- a/pmp/app-elements/interventions/intervention-form/agreement-selector.html
+++ b/pmp/app-elements/interventions/intervention-form/agreement-selector.html
@@ -61,7 +61,7 @@
         properties: {
           agreementId: {
             type: Number,
-            observer: '_agreementChanged',
+            observer: '_agreementIdChanged',
             notify: true
           },
           filteredAgreements: {
@@ -75,7 +75,8 @@
           },
           agreements: {
             type: Array,
-            statePath: 'agreementsList'
+            statePath: 'agreementsList',
+            observer: '_agreementsChanged'// Covers issues on refresh when agreements is populated after the rest of the observers run
           },
           partnerId: {
             type: Number,
@@ -91,16 +92,24 @@
             type: Boolean,
             value: false
           },
-          interventionId: Number,
+          interventionId: Number
         },
         _partnersDropdownDataChanged: function(){
           this._setSelectedPartnerId();
         },
-        _agreementChanged: function(agreementId) {
+        _agreementsChanged: function() {
+          if (this.selectedAgreement) {
+            return;
+          }
+          this._agreementIdChanged(this.agreementId);
+        },
+        _agreementIdChanged: function(agreementId) {
           var partnerSelector = this.$.partner;
           var agreementSelector = this.$.agreements;
 
-          // find the partner associated with this agreement
+          if(!this.agreements) {
+            return;
+          }
           var agreement = _.find(this.agreements, function(agreement) {
             return agreement.id === agreementId;
           });

--- a/pmp/app-elements/interventions/intervention-form/agreement-selector.html
+++ b/pmp/app-elements/interventions/intervention-form/agreement-selector.html
@@ -80,7 +80,6 @@
           partnerId: {
             type: Number,
             notify: true,
-            value: undefined,
             observer: '_partnerSelected'
           },
           selectedAgreement: {

--- a/pmp/app-elements/interventions/intervention-form/agreement-selector.html
+++ b/pmp/app-elements/interventions/intervention-form/agreement-selector.html
@@ -71,6 +71,7 @@
           partnersDropdownData: {
             type: Array,
             statePath: 'csoPartners', // 'setPartnersDropdown' Do we need to use only CSO type partners?
+            observer: '_partnersDropdownDataChanged'
           },
           agreements: {
             type: Array,
@@ -79,6 +80,7 @@
           partnerId: {
             type: Number,
             notify: true,
+            value: undefined,
             observer: '_partnerSelected'
           },
           selectedAgreement: {
@@ -90,18 +92,14 @@
             type: Boolean,
             value: false
           },
-          interventionId: Number
+          interventionId: Number,
+        },
+        _partnersDropdownDataChanged: function(){
+          this._setSelectedPartnerId();
         },
         _agreementChanged: function(agreementId) {
           var partnerSelector = this.$.partner;
           var agreementSelector = this.$.agreements;
-//          if (!agreementId) {
-//            partnerSelector.value = null,
-//            agreementSelector.value = null;
-//            this.set('filteredAgreements', []);
-//            this.set('selectedAgreement', null);
-//            return;
-//          }
 
           // find the partner associated with this agreement
           var agreement = _.find(this.agreements, function(agreement) {
@@ -109,20 +107,24 @@
           });
           this.set('selectedAgreement', agreement);
 
-          if (agreement && typeof agreement === 'object'
-              && agreement.partner && this.partnerId !== agreement.partner) {
-            var partner = _.find(this.partnersDropdownData, function(partner) {
-              return partner.id === agreement.partner;
-            });
-            if (!partner) {
-              this.fire('toast', {text: 'Selected agreement partner partner_type is not CSO!',  showCloseBtn: true});
-              // this._resetSelectorData(partnerSelector, agreementSelector);
-              return;
-            }
-            this.set('partnerId', partner.id);
+          if (this.partnersDropdownData && this.partnersDropdownData.length) {
+            this._setSelectedPartnerId();
           }
         },
-
+        _setSelectedPartnerId: function() {
+          var agreement = this.selectedAgreement;
+          if(!agreement || !agreement.partner || this.partnerId === agreement.partner) {
+            return;
+          }
+          var partner = _.find(this.partnersDropdownData, function(partner) {
+            return partner.id === agreement.partner;
+          });
+          if (!partner) {
+            this.fire('toast', {text: 'Selected agreement partner partner_type is not CSO!',  showCloseBtn: true});
+            return;
+          }
+          this.set('partnerId', partner.id);
+        },
         _filterAgreements: function(partnerId) {
           // this.$.agreements.set('value', null);
           if (!partnerId) {

--- a/pmp/app-elements/interventions/intervention-form/agreement-selector.html
+++ b/pmp/app-elements/interventions/intervention-form/agreement-selector.html
@@ -94,7 +94,7 @@
           },
           interventionId: Number
         },
-        _partnersDropdownDataChanged: function(){
+        _partnersDropdownDataChanged: function() {
           this._setSelectedPartnerId();
         },
         _agreementsChanged: function() {
@@ -107,7 +107,7 @@
           var partnerSelector = this.$.partner;
           var agreementSelector = this.$.agreements;
 
-          if(!this.agreements) {
+          if (!this.agreements) {
             return;
           }
           var agreement = _.find(this.agreements, function(agreement) {
@@ -121,7 +121,7 @@
         },
         _setSelectedPartnerId: function() {
           var agreement = this.selectedAgreement;
-          if(!agreement || !agreement.partner || this.partnerId === agreement.partner) {
+          if (!agreement || !agreement.partner || this.partnerId === agreement.partner) {
             return;
           }
           var partner = _.find(this.partnersDropdownData, function(partner) {


### PR DESCRIPTION
- Fix for 'Partner Organization' not being populated with the selected value after page refresh on Edge
- Fix for 'Agreement' not being populated after page refresh on Edge
- Fix for 'Partner focal points' not having a selected value on page refresh sometimes and when navigating from one intervention with a set Partner focal point to another intervention with a set Partner focal point
- connects unicef/etools-issues#214