### PR TITLE
Fix govt list names 

### DIFF
--- a/pmp/app-elements/governments/governments-data/governments-list-data.html
+++ b/pmp/app-elements/governments/governments-data/governments-list-data.html
@@ -96,7 +96,10 @@
               government.unicef_focal_point_names = [];
 
               for (var key in government.unicef_focal_points) {
-                government.unicef_focal_point_names.push(_this.getUserNameFromId(government.unicef_focal_points[key]));
+                var name = government.unicef_focal_points[key].name;
+                if (name) {
+                  government.unicef_focal_point_names.push(name);
+                }
               }
 
               if (selectedPartnerNames &&
@@ -107,7 +110,7 @@
 
               if (unicefFocalPoints.length) {
                 var matchUnicefFocalPoints = government.unicef_focal_points.filter(function(fPt) {
-                  return unicefFocalPoints.indexOf(fPt) > -1;
+                  return unicefFocalPoints.indexOf(fPt.id) > -1;
                 });
                 if (matchUnicefFocalPoints && matchUnicefFocalPoints.length === 0) {
                   return false;
@@ -179,6 +182,7 @@
               return this.unicefUsersData[i].full_name;
             }
           }
+          return null;
         }
 
       });


### PR DESCRIPTION
- focal point name now taken from api response
- connects unicef/etools-issues#320

This connects with unicef/etools#644. Changes from that PR are required for this to work properly 