### PR TITLE
feature(fix-ie11-colon-issue):

### DIFF
--- a/pmp/app-elements/agreements/agreement-details.html
+++ b/pmp/app-elements/agreements/agreement-details.html
@@ -398,10 +398,10 @@
           }
         },
 
-        _isSignedByFieldRequired(permission, relatedSignedByField) {
+        _isSignedByFieldRequired: function(permission, relatedSignedByField) {
           return (permission || !!relatedSignedByField);
         },
-       
+
         _getTBorderClassIfApplicable: function(agreementType) {
           if (agreementType !== 'SSFA') {
             return ' t-border';


### PR DESCRIPTION
- connects unicef/etools-issues#584
- fixed a " Missing ':' " error on ie 11