### PR TITLE
Fix partner error 

### DIFF
--- a/pmp/pages/page-agreements.html
+++ b/pmp/pages/page-agreements.html
@@ -262,7 +262,7 @@
       // },
 
       _showNewAgreementAddButton: function(agreementListActive, permissions) {
-        if (!agreementListActive || !permissions.partnershipManager) {
+        if (!agreementListActive || !permissions || !permissions.partnershipManager) {
           return false;
         }
         return true;


### PR DESCRIPTION
- connects unicef/etools-issues#589
- fixed a error with the add button not appearing on the agreements page