### PR TITLE
add bash to the docker dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM mhart/alpine-node:7
 RUN apk update
 
+RUN apk add --update bash
+
 RUN apk add git
 RUN npm install -g bower polymer-cli gulp-cli
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,6 +1,8 @@
 FROM mhart/alpine-node:7
 RUN apk update
 
+RUN apk add --update bash
+
 RUN apk add git
 RUN npm install -g polymer-cli
 


### PR DESCRIPTION
connects unicef/etools-issues#592

The issue is related to https://github.com/unicef/etools-infra/pull/21. 
As far as i can see, the PMP container is based on Alpine Linux, which does not have bash installed by default, so **fab ssh:pmp** does not work anymore. This issue may exist for other submodules too.
The fix requires the docker machine to be recreated.

EDIT
fix typo **fab ssh:backend** -> **fab ssh:pmp**
