### PR TITLE
Update countries dropdown style

### DIFF
--- a/pmp/app-elements/countries-dropdown/countries-dropdown.html
+++ b/pmp/app-elements/countries-dropdown/countries-dropdown.html
@@ -12,7 +12,6 @@
 
       :host {
         display: block;
-
       }
 
       :host(:hover) {

--- a/pmp/app-elements/countries-dropdown/countries-dropdown.html
+++ b/pmp/app-elements/countries-dropdown/countries-dropdown.html
@@ -12,6 +12,7 @@
 
       :host {
         display: block;
+
       }
 
       :host(:hover) {
@@ -44,6 +45,10 @@
           color: var(--countries-dropdown-color);
           cursor: pointer;
           min-height: 24px;
+          text-align: right;
+        };
+        --paper-menu-button-dropdown: {
+          max-height: 380px;
         }
       }
 


### PR DESCRIPTION
- connects unicef/etools-issues#341
- App Wrapper -> Country name should be aligned right next to down arrow. Country dropdown list box should be max-height: 380px