### PR TITLE
Overall fixes

### DIFF
--- a/pmp/app-elements/agreements/agreement-amendments.html
+++ b/pmp/app-elements/agreements/agreement-amendments.html
@@ -67,7 +67,7 @@
         max-width: calc(100% - 210px);
       }
       #download-template-btn {
-        max-width: 185px;
+        max-width: 220px;
         margin: 0 0 0 24px;
         padding: 0;
       }

--- a/pmp/app-elements/agreements/agreement-details.html
+++ b/pmp/app-elements/agreements/agreement-details.html
@@ -213,7 +213,7 @@
                   required$="[[_isSignedByFieldRequired(agreement.permissions.required.signed_by, agreement.signed_by_unicef_date, agreement)]]"
                   avoid-header-overlapping-dropdown>
               </etools-single-selection-menu>
-            </div>im
+            </div>
 
             <div class="col col-3">
               <!-- Signed By UNICEF Date -->

--- a/pmp/app-elements/partners/partner-overview.html
+++ b/pmp/app-elements/partners/partner-overview.html
@@ -21,7 +21,7 @@
 
   <template strip-whitespace>
 
-  <style include="page-layout-styles grid-layout-styles shared-styles risk-rating-styles data-table-styles">
+    <style include="page-layout-styles grid-layout-styles shared-styles risk-rating-styles data-table-styles">
       :host {
         @apply --layout-vertical;
         width: 100%;
@@ -141,13 +141,15 @@
         overflow: hidden;
         text-overflow: ellipsis;
       }
+
       .timeline-col {
         @apply(--layout-start-justified);
       }
+
       .timeline-col .date-delimiter {
         margin: 0 8px;
       }
-  </style>
+    </style>
     <div id="pageContent">
       <etools-content-panel class="content-section" panel-title="HACT Assurance & Partnerships">
         <div class="hact-heading">
@@ -197,48 +199,49 @@
             </div>
           </div>
         </div>
-
-        <div class="hact-heading">
-          <div class="row-h">
-            <div class="col col-3 word-break left-align"> Partnership</div>
-            <div class="col col-2 right-align"> Total Planned Budget</div>
-            <div class="col col-2 right-align"> Actual</div>
-            <div class="col col-2"> Status</div>
-            <div class="col col-3 left-align"> Timeline</div>
-          </div>
-        </div>
-        <div class="hact-body">
-          <template is="dom-repeat" items="[[partner.interventions]]" as="partnership">
+        <template is="dom-if" if="[[partner.interventions.length]]">
+          <div class="hact-heading">
             <div class="row-h">
-              <div class="col col-3 block word-break">
-                <a href="interventions/[[partnership.id]]/details"><strong>[[partnership.number]]</strong></a><br>
-                <span>
+              <div class="col col-3 word-break left-align"> Partnership</div>
+              <div class="col col-2 right-align"> Total Planned Budget</div>
+              <div class="col col-2 right-align"> Actual</div>
+              <div class="col col-2"> Status</div>
+              <div class="col col-3 left-align"> Timeline</div>
+            </div>
+          </div>
+          <div class="hact-body">
+            <template is="dom-repeat" items="[[partner.interventions]]" as="partnership">
+              <div class="row-h">
+                <div class="col col-3 block word-break">
+                  <a href="interventions/[[partnership.id]]/details"><strong>[[partnership.number]]</strong></a><br>
+                  <span>
                   [[partnership.title]]
                 </span>
+                </div>
+                <div class="col col-2 right-align"> $[[displayCurrencyAmount(partnership.total_budget, '0', 0)]]
+                </div>
+                <div class="col col-2 right-align"> $[[displayCurrencyAmount(partnership.actual_amount, '0', 0)]]</div>
+                <div class="col col-2 center-align overflow-hidden"><strong class$="[[partnership.status]]">[[partnership.status]]</strong>
+                </div>
+                <div class="col col-3 center-align timeline-col">
+                  <etools-info-tooltip icon="report" icon-first
+                                       hide-tooltip$="[[validateFrsVsInterventionDates(partnership.start, partnership.frs_earliest_start_date)]]"
+                                       important-warning>
+                    <span slot="field">[[getDateDisplayValue(partnership.start)]]</span>
+                    <span slot="message">[[getFrsStartDateValidationMsg()]]</span>
+                  </etools-info-tooltip>
+                  <span class="date-delimiter"> - </span>
+                  <etools-info-tooltip icon="report" icon-first
+                                       hide-tooltip$="[[validateFrsVsInterventionDates(partnership.end, partnership.frs_latest_end_date)]]"
+                                       important-warning>
+                    <span slot="field">[[getDateDisplayValue(partnership.end)]]</span>
+                    <span slot="message">[[getFrsEndDateValidationMsg()]]</span>
+                  </etools-info-tooltip>
+                </div>
               </div>
-              <div class="col col-2 right-align"> $[[displayCurrencyAmount(partnership.total_budget, '0', 0)]]
-              </div>
-              <div class="col col-2 right-align"> $[[displayCurrencyAmount(partnership.actual_amount, '0', 0)]]</div>
-              <div class="col col-2 center-align overflow-hidden"><strong class$="[[partnership.status]]">[[partnership.status]]</strong>
-              </div>
-              <div class="col col-3 center-align timeline-col">
-                <etools-info-tooltip icon="report" icon-first
-                                      hide-tooltip$="[[validateFrsVsInterventionDates(partnership.start, partnership.frs_earliest_start_date)]]"
-                                      important-warning>
-                  <span slot="field">[[getDateDisplayValue(partnership.start)]]</span>
-                  <span slot="message">[[getFrsStartDateValidationMsg()]]</span>
-                </etools-info-tooltip>
-                <span class="date-delimiter"> - </span>
-                <etools-info-tooltip icon="report" icon-first
-                                      hide-tooltip$="[[validateFrsVsInterventionDates(partnership.end, partnership.frs_latest_end_date)]]"
-                                      important-warning>
-                  <span slot="field">[[getDateDisplayValue(partnership.end)]]</span>
-                  <span slot="message">[[getFrsEndDateValidationMsg()]]</span>
-                </etools-info-tooltip>
-              </div>
-            </div>
-          </template>
-        </div>
+            </template>
+          </div>
+        </template>
       </etools-content-panel>
     </div>
   </template>

--- a/pmp/app-menu/app-sidebar-menu.html
+++ b/pmp/app-menu/app-sidebar-menu.html
@@ -84,7 +84,7 @@
         <span>eTools Community Channels</span>
       </div>
 
-      <a class="nav-menu-item lighter-item" href="https://etools.uservoice.com">
+      <a class="nav-menu-item lighter-item" href="https://etools.uservoice.com" target="_blank">
         <iron-icon id="knoledge-icon" icon="maps:local-library"></iron-icon>
         <paper-tooltip for="knoledge-icon" position="right">
           Knowledge base
@@ -92,7 +92,9 @@
         <div class="name">Knowledge base</div>
       </a>
 
-      <a class="nav-menu-item lighter-item" href="https://www.yammer.com/unicef.org/#/threads/inGroup?type=in_group&feedId=5782560">
+      <a class="nav-menu-item lighter-item"
+         href="https://www.yammer.com/unicef.org/#/threads/inGroup?type=in_group&feedId=5782560"
+         target="_blank">
         <iron-icon id="discussion-icon" icon="icons:question-answer"></iron-icon>
         <paper-tooltip for="discussion-icon" position="right">
           Discussion
@@ -100,7 +102,7 @@
         <div class="name">Discussion</div>
       </a>
 
-      <a class="nav-menu-item lighter-item last-one" href="http://etools.unicefresults.org">
+      <a class="nav-menu-item lighter-item last-one" href="http://etools.unicefresults.org" target="_blank">
         <iron-icon id="information-icon" icon="icons:info"></iron-icon>
         <paper-tooltip for="information-icon" position="right">
           Information

--- a/styles/page-layout-styles.html
+++ b/styles/page-layout-styles.html
@@ -101,7 +101,7 @@
       .title-row h1[main-title] {
         @apply --layout-flex;
         margin: 0;
-        /*font-weight: normal;*/
+        font-weight: normal;
         text-transform: capitalize;
         font-size: 24px;
         line-height: 1.3;


### PR DESCRIPTION
* remove `im` from agreement details
* agreement details template download btn width changed to 220px
* community links (menu) opened in new tab
* page title font weight changed to normal
* partner overview: hide partnerships columns header if there are no partnerships to display