### PR TITLE
Fix intervention overview overflowing sectors

### DIFF
--- a/pmp/app-elements/interventions/intervention-overview.html
+++ b/pmp/app-elements/interventions/intervention-overview.html
@@ -50,6 +50,7 @@
       }
 
       .sector-label {
+        display: inline-block;
         white-space: nowrap;
         height: 19px;
         text-align: center;


### PR DESCRIPTION
-fixed an issue with sector labels overflowing out of their container on the interventions overview page

- connects unicef/etools-issues#669