### PR TITLE
Fix frs amounts validation on add

### DIFF
--- a/pmp/app-elements/interventions/behaviors/fr-numbers-consistency-behavior.html
+++ b/pmp/app-elements/interventions/behaviors/fr-numbers-consistency-behavior.html
@@ -15,7 +15,7 @@
     /**
      * Check FR numbers total amount against planned budget unicef total contribution and start/end dates
      */
-    checkFrsConsistency: function(frsDetails, intervention) {
+    checkFrsConsistency: function(frsDetails, intervention, skipEmptyListCheck) {
       let warnFrsFields = []; // FR fields
       let warnIntervFields = []; // PD/SSFA fields
       if (this.checkFrsAndIntervDateConsistency(intervention.start, frsDetails.earliest_start_date)) {
@@ -27,7 +27,7 @@
         warnIntervFields.push('end date');
       }
       if (this.checkFrsAndUnicefCashAmountsConsistency(intervention.planned_budget.unicef_cash,
-              frsDetails.total_frs_amt, intervention, 'interventionDetails')) {
+              frsDetails.total_frs_amt, intervention, 'interventionDetails', false, skipEmptyListCheck)) {
         warnFrsFields.push('Total FR amount');
         warnIntervFields.push('UNICEF $ contribution');
       }
@@ -39,14 +39,16 @@
     },
 
     checkFrsAndUnicefCashAmountsConsistency: function(unicefCash, frsTotalAmt, intervention,
-      interventionIsFromWhere, returnMsg) {
-      if (!this.validateFrsVsUnicefCashAmounts(unicefCash, frsTotalAmt, intervention, interventionIsFromWhere)) {
+                                                      interventionIsFromWhere, returnMsg, skipEmptyListCheck) {
+      if (!this.validateFrsVsUnicefCashAmounts(unicefCash, frsTotalAmt, intervention, interventionIsFromWhere,
+              skipEmptyListCheck)) {
         return returnMsg ? this.getFrsTotalAmountInconsistencyMsg() : true;
       }
       return false;
     },
-    validateFrsVsUnicefCashAmounts: function(unicefCash, frsTotalAmt, intervention, interventionIsFromWhere) {
-      if (this.emptyFrsList(intervention, interventionIsFromWhere)) {
+    validateFrsVsUnicefCashAmounts: function(unicefCash, frsTotalAmt, intervention,
+                                             interventionIsFromWhere, skipEmptyListCheck) {
+      if (!skipEmptyListCheck && this.emptyFrsList(intervention, interventionIsFromWhere)) {
         return true;
       }
       let totalUnicefContribution = parseFloat(unicefCash);
@@ -81,11 +83,11 @@
     },
     getFrsStartDateValidationMsg: function() {
       return this._buildFrsWarningMsg(this._frsConsistencyWarnings.dateTmpl,
-       '<<field_name>>', 'start date');
+          '<<field_name>>', 'start date');
     },
     getFrsEndDateValidationMsg: function() {
       return this._buildFrsWarningMsg(this._frsConsistencyWarnings.dateTmpl,
-       '<<field_name>>', 'end date');
+          '<<field_name>>', 'end date');
     },
     frsConsistencyWarningIsActive: function(warnMsg) {
       return !!warnMsg;
@@ -101,7 +103,7 @@
       if (interventionIsFromWhere === 'interventionDetails') {
         return !intervention || !intervention.frs_details || intervention.frs_details.frs.length === 0;
       } else if (interventionIsFromWhere === 'interventionsList') {
-         return !intervention.frs_earliest_start_date || !intervention.frs_latest_end_date;
+        return !intervention.frs_earliest_start_date || !intervention.frs_latest_end_date;
       }
     }
 

--- a/pmp/app-elements/interventions/fr-numbers/intervention-fund-reservations.html
+++ b/pmp/app-elements/interventions/fr-numbers/intervention-fund-reservations.html
@@ -130,7 +130,7 @@
         },
 
         observers: [
-          '_frsDetailsChanged(intervention.frs_details, intervention.planned_budget.unicef_cash,' + 
+          '_frsDetailsChanged(intervention.frs_details, intervention.planned_budget.unicef_cash,' +
             ' intervention.start, intervention.end)',
         ],
 
@@ -283,7 +283,7 @@
         _frsDetailsSuccessHandler: function(e) {
           e.stopImmediatePropagation();
           let frsDetails = e.detail;
-          let warning = this.checkFrsConsistency(frsDetails, this.intervention);
+          let warning = this.checkFrsConsistency(frsDetails, this.intervention, true);
           this.set('_frsConsistencyWarning', warning);
           if (warning) {
             this._frsUpdateWarningMessage(warning);

--- a/pmp/app-elements/interventions/intervention-planned-budget.html
+++ b/pmp/app-elements/interventions/intervention-planned-budget.html
@@ -282,7 +282,7 @@
         },
 
         observers: [
-          '_checkFrsConsistency(intervention.frs_details.total_frs_amt, plannedBudget.unicef_cash)',
+          '_checkFrsAmountConsistency(intervention.frs_details.total_frs_amt, plannedBudget.unicef_cash)',
           '_initLocalCurrency(plannedBudget, countryData)'
         ],
 
@@ -391,7 +391,7 @@
           }
         },
 
-        _checkFrsConsistency: function(frsTotalAmt, unicefCash) {
+        _checkFrsAmountConsistency: function(frsTotalAmt, unicefCash) {
           let unicefCashField = this.$$('#unicefCashUsd');
           if (this.emptyFrsList(this.intervention, 'interventionDetails')) {
             this.set('_frsConsistencyWarning', '');


### PR DESCRIPTION
* add fr numbers: amount validation was skiped because intervention frs list is empty
* renamed `_checkFrsConsistency` to `_checkFrsAmountConsistency` because `_checkFrsConsistency` is already in frs consistency behavior and is different