### PR TITLE
Fix IE11 loading overlay 

### DIFF
--- a/pmp/app-behaviors/ie11-behavior.html
+++ b/pmp/app-behaviors/ie11-behavior.html
@@ -45,6 +45,9 @@
         contentContainer.style.boxSizing = 'border-box';
         contentContainer.style.paddingBottom = '90px';
       }
+      if (this.globalLoadingElement) {
+        this.globalLoadingElement.style.position = 'fixed';
+      }
     }
 
   };


### PR DESCRIPTION
- fixed an issue with the loading overlay not covering the entire page on IE11
- connects unicef/etools-issues#716