### PR TITLE
Add missing closed status 

### DIFF
--- a/pmp/app-elements/interventions/intervention-status.html
+++ b/pmp/app-elements/interventions/intervention-status.html
@@ -236,6 +236,7 @@
                 'Signed',
                 'Active',
                 'Ended',
+                'Closed',
               ];
               activeStatus = 'Ended';
               break;
@@ -247,6 +248,7 @@
                 'Signed',
                 'Active',
                 'Ended',
+                'Closed',
               ];
               activeStatus = 'Ended';
               break;


### PR DESCRIPTION
- added the missing 'Closed' status on ended interventions 
- connects unicef/etools-issues#740