### PR TITLE
Fix PD list FR errors on draft

### DIFF
--- a/pmp/app-elements/interventions/behaviors/fr-numbers-consistency-behavior.html
+++ b/pmp/app-elements/interventions/behaviors/fr-numbers-consistency-behavior.html
@@ -70,7 +70,8 @@
       return false;
     },
     validateFrsVsInterventionDates: function(intervDateStr, frsDateStr) {
-      if (!frsDateStr) {// *No Fr added
+      if (!frsDateStr || !intervDateStr) {
+        // No Fr added or interv dates not set yet
         return true;
       }
       if (intervDateStr !== frsDateStr) {

--- a/pmp/app-elements/interventions/interventions-list.html
+++ b/pmp/app-elements/interventions/interventions-list.html
@@ -792,8 +792,8 @@
           this.set('pageNumber', 1);
         },
 
-        _hideFrsWarningTooltip: function(date1, date2, status) {
-          return status === 'draft' || this.validateFrsVsInterventionDates(date1, date2);
+        _hideFrsWarningTooltip: function(pdDate, frsDate, status) {
+          return status === 'draft' || this.validateFrsVsInterventionDates(pdDate, frsDate);
         }
 
       });

--- a/pmp/app-elements/interventions/interventions-list.html
+++ b/pmp/app-elements/interventions/interventions-list.html
@@ -188,7 +188,7 @@
             </span>
             <span class="col-data flex-c">
               <etools-info-tooltip icon="report" icon-first
-                                   hide-tooltip$="[[validateFrsVsInterventionDates(intervention.start, intervention.frs_earliest_start_date)]]"
+                                   hide-tooltip$="[[_hideFrsWarningTooltip(intervention.start, intervention.frs_earliest_start_date, intervention.status)]]"
                                    important-warning>
                 <span slot="field">[[getDateDisplayValue(intervention.start)]]</span>
                 <span slot="message">[[getFrsStartDateValidationMsg()]]</span>
@@ -196,7 +196,7 @@
             </span>
             <span class="col-data flex-c">
                <etools-info-tooltip icon="report" icon-first
-                                    hide-tooltip$="[[validateFrsVsInterventionDates(intervention.end, intervention.frs_latest_end_date)]]"
+                                    hide-tooltip$="[[_hideFrsWarningTooltip(intervention.end, intervention.frs_latest_end_date, intervention.status)]]"
                                     important-warning>
                  <span slot="field">[[getDateDisplayValue(intervention.end)]]</span>
                  <span slot="message">[[getFrsEndDateValidationMsg()]]</span>
@@ -790,6 +790,10 @@
         _filtersChanged: function() {
           this.set('debounceTime', 200);
           this.set('pageNumber', 1);
+        },
+
+        _hideFrsWarningTooltip: function(date1, date2, status) {
+          return status === 'draft' || this.validateFrsVsInterventionDates(date1, date2);
         }
 
       });


### PR DESCRIPTION
- fr warnings were appearing on the list if a draft did not have inter. dates set yet
- connects unicef/etools-issues#761