### PR TITLE
Remove arabic from generate PCA dialog 

### DIFF
--- a/pmp/app-elements/agreements/generate-PCA-dialog.html
+++ b/pmp/app-elements/agreements/generate-PCA-dialog.html
@@ -38,7 +38,7 @@
         templateOptions: {
           type: Array,
           value: function() {
-            return [{value: 'arabic', label: 'Arabic'}, {value: 'english', label: 'English'},
+            return [{value: 'english', label: 'English'},
              {value: 'french', label: 'French'}, {value: 'portuguese', label: 'Portuguese'},
              {value: 'russian', label: 'Russian'}, {value: 'spanish', label: 'Spanish'},
              {value: 'ifrc_english', label: 'IFRC English'}, {value: 'ifrc_french', label: 'IFRC French'}];


### PR DESCRIPTION
- removed the arabic option from the generate pca dialog
- connects unicef/etools-issues#754