### PR TITLE
Fix add indicator btn on new pd page

### DIFF
--- a/pmp/app-elements/interventions/intervention-details.html
+++ b/pmp/app-elements/interventions/intervention-details.html
@@ -297,16 +297,23 @@
         </etools-form-element-wrapper>
       </div>
     </etools-content-panel>
-
+    
     <etools-content-panel class="content-section" panel-title="PD output or SSFA expected result">
-      <intervention-expected-results id="expectedResults"
-                                     data-items="{{intervention.result_links}}"
-                                     selected-cp-structure="[[intervention.country_programme]]"
-                                     intervention-id="[[intervention.id]]"
-                                     edit-mode$="[[intervention.permissions.edit.result_links]]"
-                                     on-indicators-changed="_updateInteventionLocAndClusters">
-      </intervention-expected-results>
-    </etools-content-panel>
+      <template is="dom-if" if="[[!newIntervention]]">
+        <intervention-expected-results id="expectedResults"
+                                      data-items="{{intervention.result_links}}"
+                                      selected-cp-structure="[[intervention.country_programme]]"
+                                      intervention-id="[[intervention.id]]"
+                                      edit-mode$="[[intervention.permissions.edit.result_links]]"
+                                      on-indicators-changed="_updateInteventionLocAndClusters">
+        </intervention-expected-results>
+      </template>
+      <template is="dom-if" if="[[newIntervention]]">
+        <div class="row-h">        
+          <p> You must save this PD/SSFA before you can add expected results. </p>
+        </div>
+        </template>          
+      </etools-content-panel>
 
     <intervention-planned-budget id="plannedBudget"
                                  class="content-section"


### PR DESCRIPTION
- removed add indicator button from new pd page
- connects unicef/etools-issues#885