### PR TITLE
Fix pd attachment permissions issue

### DIFF
--- a/pmp/app-config/app-user-permissions-behavior.html
+++ b/pmp/app-config/app-user-permissions-behavior.html
@@ -33,6 +33,7 @@
          'partnershipManager',
          'editPartnerDetails',
          'editAgreementDetails',
+         'editInterventionDetails'
        ],
        PMEPermissions: [
          'PME'


### PR DESCRIPTION
- fixed an issue with missing permissions on the PD details page
- connects unicef/etools-issues#901