### PR TITLE
fix: refresh list data after item was saved & new PD tabs

### DIFF
--- a/pmp/modules/app-modules/interventions/mixins/intervention-page-tabs-mixin.html
+++ b/pmp/modules/app-modules/interventions/mixins/intervention-page-tabs-mixin.html
@@ -65,18 +65,16 @@
             return;
           }
           let showPrpTabs = this.showPrpReports();
-          this.interventionTabs.forEach((t, index) => {
+          let tabs = JSON.parse(JSON.stringify(this.interventionTabs));
+          tabs.forEach((t) => {
             if (t.tab === 'overview') {
-              this._updateTabProperty(index, 'hidden', newInterventionActive);
+              t.hidden = newInterventionActive;
             }
             if (['reports', 'progress'].indexOf(t.tab) > -1) {
-              this._updateTabProperty(index, 'hidden', !showPrpTabs || newInterventionActive);
+              t.hidden = !showPrpTabs || newInterventionActive;
             }
           });
-        }
-
-        _updateTabProperty(tabIndex, property, value) {
-          this.set(['interventionTabs', tabIndex, property], value);
+          this.set('interventionTabs', tabs);
         }
 
       });

--- a/pmp/modules/app-modules/mixins/module-common-mixin.html
+++ b/pmp/modules/app-modules/mixins/module-common-mixin.html
@@ -96,7 +96,7 @@
         _reloadListData(e) {
           e.stopImmediatePropagation();
           try {
-            let listElem = this.$.list;
+            let listElem = this.shadowRoot.querySelector('#list');
             if (listElem && !listElem.classList.contains('hidden')) {
               listElem._filterListData(true);
             }


### PR DESCRIPTION
[ch5073]
- Shared Partners modification made in Partner Details  is not updated in Partners List if after modification user hits save and then back from browser(Partner Details is expanded all times)

- ADD NEW PD/SSFA shows all tabs from PD/SSFA Details, if a PD/SSFA Details is open, click on PD/SSFA and ADD NEW PD/SSFA(when you try to open OVERVIEW/REPORTS/PROGRESS  enters in continue loading process)
