### PR TITLE
Partner assurance tab updates

### DIFF
--- a/pmp/modules/app-modules/interventions/pages/overview/components/monitoring-visits-list.html
+++ b/pmp/modules/app-modules/interventions/pages/overview/components/monitoring-visits-list.html
@@ -90,7 +90,7 @@
         </template>
       </div>
       <div class="row-h" hidden$="[[!_hideMonitoringVisits(monitoringVisits.length)]]">
-        <p>There are no monitoring visits for this intervention.</p>
+        <p>There are no monitoring visits.</p>
       </div>
     </div>
 

--- a/pmp/modules/app-modules/partners/pages/financial-assurance/partner-financial-assurance.html
+++ b/pmp/modules/app-modules/partners/pages/financial-assurance/partner-financial-assurance.html
@@ -215,8 +215,8 @@
         </div>
         <div class="col col-2 center-align hact-values">
           [[partner.hact_values.programmatic_visits.planned.total]] /
-          [[partner.hact_min_requirements.programme_visits]] /
-          <span class="green"> [[partner.hact_values.programmatic_visits.completed.total]]</span>
+          <span class="green"> [[partner.hact_min_requirements.programme_visits]]</span> /
+          [[partner.hact_values.programmatic_visits.completed.total]]
         </div>
         <div class="col col-2 center-align hact-values">
           <strong>
@@ -414,8 +414,7 @@
 
     <etools-content-panel id="monitoring-visits-panel" class="content-section" panel-title="Programmatic Visits">
       <monitoring-visits-list intervention-or-partner-id="[[partner.id]]"
-                              endpoint-name="partnerProgrammaticVisits">
-
+                              endpoint-name="partnerT2fProgrammaticVisits">
       </monitoring-visits-list>
     </etools-content-panel>
 

--- a/pmp/modules/app-modules/partners/pages/overview/partner-overview.html
+++ b/pmp/modules/app-modules/partners/pages/overview/partner-overview.html
@@ -116,7 +116,7 @@
           <div class="col col-2"> Risk Rating</div>
           <div class="col col-2"> Current CP Cycle</div>
           <div class="col col-2"> Current Year (Jan - Dec)</div>
-          <div class="col col-2"> Planned / M.R. / Done</div>
+          <div class="col col-2"> Planned / M.R. / Completed</div>
           <div class="col col-2"> Required / Completed</div>
           <div class="col col-2"> Required / Completed</div>
         </div>

--- a/pmp/modules/endpoints/endpoints.html
+++ b/pmp/modules/endpoints/endpoints.html
@@ -114,8 +114,8 @@
     monitoringVisits: {
       template: '/api/t2f/travels/activities/partnership/<%=id%>/?year=<%=year%>'
     },
-    partnerProgrammaticVisits: {
-      template: '/api/t2f/travels/activities/<%=id%>/?year=<%=year%>'
+    partnerT2fProgrammaticVisits: {
+      template: '/api/t2f/travels/activities/<%=id%>/?year=<%=year%>&status=completed'
     },
     sectorLocationsDelete: {
       template: '/api/v2/interventions/sector-locations/<%=id%>/'


### PR DESCRIPTION
[ch6127]
[ch6137]

`/api/t2f/travels/activities/<%=id%>/?year=<%=year%>&status=completed` status param is ignored right now... wait for BE changes.