### PR TITLE
Partners new upload component integration

### DIFF
--- a/pmp/modules/app-modules/agreements/agreements-module.html
+++ b/pmp/modules/app-modules/agreements/agreements-module.html
@@ -512,7 +512,9 @@
             changes.country_programme = this.agreement.country_programme;
           }
           if (this._objectFieldIsModified('amendments')) {
-            changes.amendments = this.agreement.amendments;
+            // keep only new amendments
+            changes.amendments = this.agreement.amendments.filter(
+                a => !a.id && typeof a.signed_amendment_attachment === 'number' && a.signed_amendment_attachment > 0);
           }
           if (this._primitiveFieldIsModified('special_conditions_pca')) {
             changes.special_conditions_pca = this.agreement.special_conditions_pca;

--- a/pmp/modules/app-modules/agreements/data/agreement-item-data.html
+++ b/pmp/modules/app-modules/agreements/data/agreement-item-data.html
@@ -229,11 +229,7 @@
             if (succCallback) {
               this.set('handleSuccResponseAdditionalCallback', succCallback);
             }
-            let withUpload = false; // used to set multipart prop on etools-ajax
-            if (this._hasFiles(agreement.amendments, 'signed_amendment')) {
-              agreement.amendments = agreement.amendments.filter(a => !a.id); // send only newlly added
-              withUpload = true;
-            }
+
             this.fireEvent('global-loading', {
               message: 'Saving...',
               active: true,
@@ -244,9 +240,7 @@
             this._triggerAgreementRequest({
               method: method,
               endpoint: endpoint,
-              body: agreement,
-              multiPart: withUpload,
-              prepareMultipartData: withUpload
+              body: agreement
             });
           } else {
             this.fireEvent('toast', {

--- a/pmp/modules/app-modules/agreements/pages/details/components/amendments/add-ag-amendment-dialog.html
+++ b/pmp/modules/app-modules/agreements/pages/details/components/amendments/add-ag-amendment-dialog.html
@@ -236,10 +236,8 @@
       }
 
       _uploadFinished(e) {
-        console.log(e);
         if (e.detail.success) {
           const uploadResponse = JSON.parse(e.detail.success);
-          console.log(uploadResponse);
           this.set('amendment.signed_amendment_attachment', uploadResponse.id);
         }
       }

--- a/pmp/modules/app-modules/agreements/pages/details/components/amendments/add-ag-amendment-dialog.html
+++ b/pmp/modules/app-modules/agreements/pages/details/components/amendments/add-ag-amendment-dialog.html
@@ -8,7 +8,6 @@
 
 <link rel="import" href="../../../../../../validators/required-and-not-future-date-validator.html">
 <link rel="import" href="../../../../../../layout/components/etools-date-input.html">
-<!--<link rel="import" href="../../../../../../layout/components/etools-single-file.html">-->
 
 <link rel="import" href="../../../../../../endpoints/endpoints.html">
 <link rel="import" href="../../../../../../mixins/event-helper-mixin.html">
@@ -48,6 +47,7 @@
                              value="{{amendment.signed_date}}"
                              error-message="Please select signed date"
                              no-init show-clear-btn
+                             open="{{datePickerOpen}}"
                              validator="ag_am_signed_date_validator"
                              auto-validate="[[autoValidate]]"
                              required-and-not-future-date>
@@ -66,15 +66,6 @@
                        auto-validate="[[autoValidate]]"
                        error-message="Signed Amendment file is required">
         </etools-upload>
-        <!--<etools-single-file id="signedAmendment"-->
-                            <!--label="Signed Amendment"-->
-                            <!--file="{{amendment.signed_amendment}}"-->
-                            <!--internal-file="{{amendment.signed_amendment_file}}"-->
-                            <!--error-message="Signed Amendment file is required"-->
-                            <!--required-->
-                            <!--auto-validate="[[autoValidate]]"-->
-                            <!--accept=".doc,.docx,.pdf,.jpg,.png">-->
-        <!--</etools-single-file>-->
       </div>
 
       <div class="row-h flex-c">

--- a/pmp/modules/app-modules/agreements/pages/details/components/amendments/add-ag-amendment-dialog.html
+++ b/pmp/modules/app-modules/agreements/pages/details/components/amendments/add-ag-amendment-dialog.html
@@ -4,11 +4,13 @@
 <link rel="import" href="../../../../../../../../bower_components/etools-behaviors/etools-mixin-factory.html">
 <link rel="import" href="../../../../../../../../bower_components/etools-dialog/etools-dialog.html">
 <link rel="import" href="../../../../../../../../bower_components/etools-dropdown/etools-dropdown-multi.html">
+<link rel="import" href="../../../../../../../../bower_components/etools-upload/etools-upload.html">
 
 <link rel="import" href="../../../../../../validators/required-and-not-future-date-validator.html">
 <link rel="import" href="../../../../../../layout/components/etools-date-input.html">
-<link rel="import" href="../../../../../../layout/components/etools-single-file.html">
+<!--<link rel="import" href="../../../../../../layout/components/etools-single-file.html">-->
 
+<link rel="import" href="../../../../../../endpoints/endpoints.html">
 <link rel="import" href="../../../../../../mixins/event-helper-mixin.html">
 
 <link rel="import" href="../../../../../../styles/shared-styles.html">
@@ -54,15 +56,25 @@
       </div>
       <div class="row-h flex-c">
         <!-- Signed Agreement -->
-        <etools-single-file id="signedAmendment"
-                            label="Signed Amendment"
-                            file="{{amendment.signed_amendment}}"
-                            internal-file="{{amendment.signed_amendment_file}}"
-                            error-message="Signed Amendment file is required"
-                            required
-                            auto-validate="[[autoValidate]]"
-                            accept=".doc,.docx,.pdf,.jpg,.png">
-        </etools-single-file>
+        <etools-upload id="signedAmendment"
+                       label="Signed Amendment"
+                       accept=".doc,.docx,.pdf,.jpg,.png"
+                       file-url="[[amendment.signed_amendment_attachment]]"
+                       upload-endpoint="[[uploadEndpoint]]"
+                       on-upload-finished="_uploadFinished"
+                       required
+                       auto-validate="[[autoValidate]]"
+                       error-message="Signed Amendment file is required">
+        </etools-upload>
+        <!--<etools-single-file id="signedAmendment"-->
+                            <!--label="Signed Amendment"-->
+                            <!--file="{{amendment.signed_amendment}}"-->
+                            <!--internal-file="{{amendment.signed_amendment_file}}"-->
+                            <!--error-message="Signed Amendment file is required"-->
+                            <!--required-->
+                            <!--auto-validate="[[autoValidate]]"-->
+                            <!--accept=".doc,.docx,.pdf,.jpg,.png">-->
+        <!--</etools-single-file>-->
       </div>
 
       <div class="row-h flex-c">
@@ -124,6 +136,7 @@
             type: Boolean,
             value: false
           },
+          uploadEndpoint: String,
           amendmentTypes: {
             type: Array,
             value: []
@@ -135,8 +148,7 @@
               id: null,
               signed_date: null,
               types: [],
-              signed_amendment: null,
-              signed_amendment_file: null
+              signed_amendment_attachment: null
             }
           },
           autoValidate: {
@@ -164,6 +176,11 @@
             value: ['#signedDate', '#signedAmendment', '#amendmentTypes', '#officers']
           }
         };
+      }
+
+      connectedCallback() {
+        super.connectedCallback();
+        this.set('uploadEndpoint', EtoolsPmpApp.Endpoints.attachmentsUpload.url);
       }
 
       initData(authorizedOfficers, showAuthorizedOfficers, amendmentTypes) {
@@ -225,6 +242,15 @@
           return false;
         }
         return this.amendment.types.indexOf('Change authorized officer') > -1;
+      }
+
+      _uploadFinished(e) {
+        console.log(e);
+        if (e.detail.success) {
+          const uploadResponse = JSON.parse(e.detail.success);
+          console.log(uploadResponse);
+          this.set('amendment.signed_amendment_attachment', uploadResponse.id);
+        }
       }
 
     }

--- a/pmp/modules/app-modules/agreements/pages/details/components/amendments/agreement-amendments.html
+++ b/pmp/modules/app-modules/agreements/pages/details/components/amendments/agreement-amendments.html
@@ -153,8 +153,8 @@
                 <span class="break-word">
                   <!-- target="_blank" is there for IE -->
                   <template is="dom-if" if="[[item.id]]" restamp>
-                    <a href$="[[item.signed_amendment_file]]"
-                       target="_blank" download>[[getFileNameFromURL(item.signed_amendment_file)]]</a>
+                    <a href$="[[item.signed_amendment_attachment]]"
+                       target="_blank" download>[[getFileNameFromURL(item.signed_amendment_attachment)]]</a>
                   </template>
                   <template is="dom-if" if="[[!item.id]]" restamp>
                     <span>[[item.signed_amendment.name]]</span>

--- a/pmp/modules/app-modules/partners/data/partner-item-data.html
+++ b/pmp/modules/app-modules/partners/data/partner-item-data.html
@@ -247,20 +247,27 @@
             if (callback) {
               this.set('handleSuccResponseAdditionalCallback', callback);
             }
-            let withUpload = false; // used to set multipart prop on etools-ajax
-            if (partner.hasOwnProperty('core_values_assessments')) {
-              if (partner.core_values_assessments.length) {
-                for(let i = 0; i < partner.core_values_assessments.length; i++) {
-                  if (partner.core_values_assessments[i].assessment instanceof File) {
-                    withUpload = true;
-                    break;
-                  }
-                }
-                if (!withUpload) {
-                delete partner.core_values_assessments;
-                }
-              }
+
+            partner.core_values_assessments =
+                partner.core_values_assessments.filter(c => typeof c.attachment === 'number' && c.attachment > 0);
+            if (partner.core_values_assessments.length === 0) {
+              delete partner.core_values_assessments;
             }
+
+            let withUpload = false; // used to set multipart prop on etools-ajax
+            // if (partner.hasOwnProperty('core_values_assessments')) {
+            //   if (partner.core_values_assessments.length) {
+            //     for(let i = 0; i < partner.core_values_assessments.length; i++) {
+            //       if (partner.core_values_assessments[i].assessment instanceof File) {
+            //         withUpload = true;
+            //         break;
+            //       }
+            //     }
+            //     if (!withUpload) {
+            //     delete partner.core_values_assessments;
+            //     }
+            //   }
+            // }
             if (partner.hasOwnProperty('assessments')) {
               if ((Array.isArray(partner.assessments)) && (partner.assessments.length > 0)) {
                 partner.assessments = partner.assessments.map(function(assessment) {

--- a/pmp/modules/app-modules/partners/pages/details/components/edit-core-values-assessment.html
+++ b/pmp/modules/app-modules/partners/pages/details/components/edit-core-values-assessment.html
@@ -21,7 +21,9 @@
     </style>
 
     <etools-dialog id="cvaDialog" dialog-title="Upload Core Values Assessment" size="md"
-                   ok-btn-text="Save" keep-dialog-open on-confirm-btn-clicked="_saveCoreValueAssessment">
+                   ok-btn-text="Save" keep-dialog-open on-confirm-btn-clicked="_saveCoreValueAssessment"
+                   disable-confirm-btn="[[uploadInProgress]]"
+                   disable-dismiss-btn="[[uploadInProgress]]">
       <div class="layout-horizontal row-padding-v">
         <etools-form-element-wrapper label="Date Last Assessed"
                                      value="[[prettyDate(item.date)]]">
@@ -34,6 +36,7 @@
                        file-url="[[item.attachment]]"
                        upload-endpoint="[[uploadEndpoint]]"
                        on-upload-finished="_uploadFinished"
+                       upload-in-progress="{{uploadInProgress}}"
                        required
                        error-message="Assessment file is required">
         </etools-upload>
@@ -65,6 +68,10 @@
             value: function() {
               return EtoolsPmpApp.Endpoints.attachmentsUpload.url;
             }
+          },
+          uploadInProgress: {
+            type: Boolean,
+            value: false
           }
         };
       }

--- a/pmp/modules/app-modules/partners/pages/details/components/edit-core-values-assessment.html
+++ b/pmp/modules/app-modules/partners/pages/details/components/edit-core-values-assessment.html
@@ -1,8 +1,8 @@
 <link rel="import" href="../../../../../../../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../../../../../../../bower_components/etools-dialog/etools-dialog.html">
 <link rel="import" href="../../../../../../../bower_components/paper-input/paper-input.html">
+<link rel="import" href="../../../../../../../bower_components/etools-upload/etools-upload.html">
 
-<link rel="import" href="../../../../../layout/components/etools-single-file.html">
 <link rel="import" href="../../../../../layout/components/etools-form-element-wrapper.html">
 <link rel="import" href="../../../../../mixins/event-helper-mixin.html">
 <link rel="import" href="../../../../../mixins/common-mixin.html">
@@ -22,18 +22,20 @@
     <etools-dialog id="cvaDialog" dialog-title="Upload Core Values Assessment" size="md"
                    ok-btn-text="Save" keep-dialog-open on-confirm-btn-clicked="_saveCoreValueAssessment">
       <div class="layout-horizontal row-padding-v">
-          <etools-form-element-wrapper label="Date Last Assessed"
-                    value="[[prettyDate(item.date)]]">
-          </etools-form-element-wrapper>
+        <etools-form-element-wrapper label="Date Last Assessed"
+                                     value="[[prettyDate(item.date)]]">
+        </etools-form-element-wrapper>
       </div>
       <div class="layout-horizontal row-padding-v">
-          <etools-single-file id="attachment"
-                    file="{{item.assessment}}"
-                    internal-file="{{item.assessment_file}}"
-                    label="Core Values Assessment"
-                    required
-                    accept=".doc,.docx,.pdf,.jpg,.png">
-          </etools-single-file>
+        <etools-upload id="attachment"
+                       label="Core Values Assessment"
+                       accept=".doc,.docx,.pdf,.jpg,.png"
+                       file-url="[[item.attachment]]"
+                       upload-endpoint="[[uploadEndpoint]]"
+                       on-upload-finished="_uploadFinished"
+                       required
+                       error-message="Assessment file is required">
+        </etools-upload>
       </div>
     </etools-dialog>
 
@@ -46,8 +48,7 @@
      * @appliesMixin EtoolsPmpApp.Mixins.Common
      * @appliesMixin EtoolsPmpApp.Mixins.EventHelper
      */
-    class EditCoreValuesAssessment extends EtoolsPmpApp.Mixins.EventHelper(
-          EtoolsPmpApp.Mixins.Common(Polymer.Element)) {
+    class EditCoreValuesAssessment extends EtoolsPmpApp.Mixins.Common(Polymer.Element) {
       static get is() {
         return 'edit-core-values-assessment';
       }
@@ -56,6 +57,13 @@
         return {
           item: {
             type: Object
+          },
+          parent: Object,
+          uploadEndpoint: {
+            type: String,
+            value: function() {
+              return EtoolsPmpApp.Endpoints.attachmentsUpload.url;
+            }
           }
         };
       }
@@ -68,8 +76,15 @@
         if (!this.shadowRoot.querySelector('#attachment').validate()) {
           return;
         }
-        this.fireEvent('save-core-values-assessment', this.item);
+        this.parent.fireEvent('save-core-values-assessment', this.item);
         this.$.cvaDialog.opened = false;
+      }
+
+      _uploadFinished(e) {
+        if (e.detail.success) {
+          const uploadResponse = JSON.parse(e.detail.success);
+          this.set('item.attachment', uploadResponse.id);
+        }
       }
 
     }

--- a/pmp/modules/app-modules/partners/pages/details/partner-details.html
+++ b/pmp/modules/app-modules/partners/pages/details/partner-details.html
@@ -172,7 +172,7 @@
             <div>(from VISION)</div>
           </etools-data-table-column>
           <etools-data-table-column class="col-6">
-            Core Values Assesment
+            Core Values Assessment
           </etools-data-table-column>
           <etools-data-table-column class="col-2">
             Archived
@@ -180,7 +180,7 @@
         </etools-data-table-header>
         <template is="dom-repeat" items="{{partner.core_values_assessments}}">
           <etools-data-table-row no-collapse
-            secondary-bg-on-hover$="[[_canEditCVA(item.assessment_file, item.archived, showCoreValuesAssessmentAttachment)]]"
+            secondary-bg-on-hover$="[[_canEditCVA(item.attachment, item.archived, showCoreValuesAssessmentAttachment)]]"
             hidden$="[[!_shouldShowCVA(item.archived, showArchivedAssessments)]]">
             <div slot="row-data" class="p-relative">
               <span class="col-data col-4">
@@ -188,16 +188,17 @@
                 <span hidden$="[[!_isEmptyDate(item.date)]]" class="placeholder-style">&#8212;</span>
               </span>
               <span class="col-data col-6">
-                  <iron-icon icon="attachment" hidden$="[[!item.assessment_file]]"></iron-icon>
-                  <span hidden$="[[item.assessment_file]]" class="placeholder-style">&#8212;</span>
-                  <a class="cvs-file" href$="[[item.assessment_file]]"
-                     target="_blank" download>[[getFileNameFromURL(item.assessment_file)]]</a>
+                  <iron-icon icon="attachment" hidden$="[[!item.attachment]]"></iron-icon>
+                  <span hidden$="[[item.attachment]]" class="placeholder-style">&#8212;</span>
+                  <a class="cvs-file" href$="[[item.attachment]]"
+                     target="_blank" download>[[getFileNameFromURL(item.attachment)]]</a>
               </span>
               <span class="col-data col-2">
+                <span hidden$="[[item.archived]]" class="placeholder-style">&#8212;</span>
                 <iron-icon icon="check" hidden$="[[!item.archived]]"></iron-icon>
               </span>
               <icons-actions item$="[[item]]"
-                      hidden$="[[!_canEditCVA(item.assessment_file, item.archived, showCoreValuesAssessmentAttachment)]]"
+                      hidden$="[[!_canEditCVA(item.attachment, item.archived, showCoreValuesAssessmentAttachment)]]"
                       show-delete="[[showDelete]]"
                       on-edit="_editCoreValuesAssessment">
               </icons-actions>
@@ -316,22 +317,13 @@
 
       _createEditCoreValuesAssessmentsDialog() {
         this.editCVADialog = document.createElement('edit-core-values-assessment');
-        this.editCVADialog.addEventListener('save-core-values-assessment',
-            this._saveCoreValuesAssessment.bind(this));
+        this.editCVADialog.parent = this;
         document.querySelector('body').appendChild(this.editCVADialog);
       }
 
       _editCoreValuesAssessment(e) {
         this.editCVADialog.item = JSON.parse(e.target.getAttribute('item'));
         this.editCVADialog.open();
-      }
-
-      _saveCoreValuesAssessment(e) {
-        this.fireEvent('save-core-values-assessment', e.detail);
-      }
-
-      _hideDeleteBtn() {
-        return this.partner && this.partner.core_values_assessment_file;
       }
 
       _canEditCVA(attachment, archived) {
@@ -347,7 +339,7 @@
           this.set('showCoreValuesAssessmentAttachment',
               this._showCoreValueAssessment(partner.partner_type, partner.cso_type));
 
-          if (this.showCoreValuesAssessmentAttachment && partner.core_values_assessment_file) {
+          if (this.showCoreValuesAssessmentAttachment) {
             this._displayAssessmentNotification(partner.core_values_assessment_date, 'Core Values Assessment');
           }
           if (partner.type_of_assessment === 'Micro Assessment') {
@@ -367,24 +359,24 @@
         });
       }
 
-      _displayAssessmentNotification(assesmentDateString, assesmentType) {
-        if (!assesmentDateString) {
+      _displayAssessmentNotification(assessmentDateString, assessmentType) {
+        if (!assessmentDateString) {
           return;
         }
         let datesFormat = 'YYYY-MM-DD';
         let today = moment.utc().format(datesFormat);
-        let assessmentDate = this._convertDate(assesmentDateString);
+        let assessmentDate = this._convertDate(assessmentDateString);
         let assessmentExpDate = moment(assessmentDate).add(60, 'months');
 
         let daysUntilExpire = assessmentExpDate.diff(today, 'days');
 
         let notifMessage = '';
         if (daysUntilExpire < 1) {
-          notifMessage = 'The ' + assesmentType + ' is expired (' + assessmentExpDate.format(datesFormat) + ')';
+          notifMessage = 'The ' + assessmentType + ' is expired (' + assessmentExpDate.format(datesFormat) + ')';
         } else {
           let notifStartDate = moment(assessmentDate).add(57, 'months');
           if (moment(today).isAfter(notifStartDate)) {
-            notifMessage = 'The ' + assesmentType + ' will expire in ' + daysUntilExpire + ' days';
+            notifMessage = 'The ' + assessmentType + ' will expire in ' + daysUntilExpire + ' days';
           }
         }
         if (notifMessage) {

--- a/pmp/modules/app-modules/partners/pages/details/partner-details.html
+++ b/pmp/modules/app-modules/partners/pages/details/partner-details.html
@@ -327,6 +327,7 @@
       }
 
       _canEditCVA(attachment, archived) {
+        return true;
         if (attachment || archived) {
           return false;
         }

--- a/pmp/modules/app-modules/partners/pages/details/partner-details.html
+++ b/pmp/modules/app-modules/partners/pages/details/partner-details.html
@@ -327,7 +327,6 @@
       }
 
       _canEditCVA(attachment, archived) {
-        return true;
         if (attachment || archived) {
           return false;
         }

--- a/pmp/modules/styles/required-field-styles.html
+++ b/pmp/modules/styles/required-field-styles.html
@@ -18,6 +18,7 @@
       etools-date-input[required],
       etools-dropdown[required],
       etools-dropdown-multi[required],
+      etools-upload[required],
       etools-single-file[required],
       etools-file[required],
       etools-currency-amount-input[required] {


### PR DESCRIPTION
[ch6586] - partner file uploads updates

BE issues:
* Core Values Assessments upload not working, no error on save request, but it's not returning uploaded file url in `attachment` property as it should.

* Partner assessments upload(new property used: `report_attachment`) has issues on save with the old upload properties `report` and `report_file`. It returns 400 errors `No file was submitted` if I remove old upload properties from request payload or if I keep them and `report` property is not a file.