### PR TITLE
partner assessments attachments updates to use new upload component

### DIFF
--- a/pmp/modules/app-modules/partners/data/partner-item-data.html
+++ b/pmp/modules/app-modules/partners/data/partner-item-data.html
@@ -248,52 +248,6 @@
               this.set('handleSuccResponseAdditionalCallback', callback);
             }
 
-            if (partner.core_values_assessments instanceof Array) {
-              partner.core_values_assessments =
-                  partner.core_values_assessments.filter(c => typeof c.attachment === 'number' && c.attachment > 0);
-              if (partner.core_values_assessments.length === 0) {
-                delete partner.core_values_assessments;
-              }
-            }
-
-            if (partner.assessments instanceof Array) {
-              partner.assessments = partner.assessments.filter(
-                  a => typeof a.report_attachment === 'number' && a.report_attachment > 0);
-              if (partner.assessments.length === 0) {
-                delete partner.assessments;
-              } else {
-                partner.assessments = partner.assessments.map((a) => {
-                  return Object.assign({}, a, {report: a.report_attachment, report_attachment: null});
-                });
-              }
-            }
-
-            // let withUpload = false; // used to set multipart prop on etools-ajax
-            // if (partner.hasOwnProperty('core_values_assessments')) {
-            //   if (partner.core_values_assessments.length) {
-            //     for(let i = 0; i < partner.core_values_assessments.length; i++) {
-            //       if (partner.core_values_assessments[i].assessment instanceof File) {
-            //         withUpload = true;
-            //         break;
-            //       }
-            //     }
-            //     if (!withUpload) {
-            //     delete partner.core_values_assessments;
-            //     }
-            //   }
-            // }
-            // if (partner.hasOwnProperty('assessments')) {
-            //   if ((Array.isArray(partner.assessments)) && (partner.assessments.length > 0)) {
-            //     partner.assessments = partner.assessments.map(function(assessment) {
-            //       if (assessment.report instanceof File) {
-            //         withUpload = true;
-            //       } else {
-            //         delete assessment.report;
-            //       }
-            //       return assessment;
-            //     }, this);
-            //   }
-            // }
             this.fireEvent('global-loading', {
               message: 'Saving...',
               active: true,
@@ -302,7 +256,6 @@
             // fire in the hole
             this._triggerPartnerRequest({
               method: 'PATCH', endpoint: endpoint, body: partner
-              // multiPart: withUpload, prepareMultipartData: withUpload
             });
           } else {
             this.fireEvent('toast', {

--- a/pmp/modules/app-modules/partners/data/partner-item-data.html
+++ b/pmp/modules/app-modules/partners/data/partner-item-data.html
@@ -248,13 +248,27 @@
               this.set('handleSuccResponseAdditionalCallback', callback);
             }
 
-            partner.core_values_assessments =
-                partner.core_values_assessments.filter(c => typeof c.attachment === 'number' && c.attachment > 0);
-            if (partner.core_values_assessments.length === 0) {
-              delete partner.core_values_assessments;
+            if (partner.core_values_assessments instanceof Array) {
+              partner.core_values_assessments =
+                  partner.core_values_assessments.filter(c => typeof c.attachment === 'number' && c.attachment > 0);
+              if (partner.core_values_assessments.length === 0) {
+                delete partner.core_values_assessments;
+              }
             }
 
-            let withUpload = false; // used to set multipart prop on etools-ajax
+            if (partner.assessments instanceof Array) {
+              partner.assessments = partner.assessments.filter(
+                  a => typeof a.report_attachment === 'number' && a.report_attachment > 0);
+              if (partner.assessments.length === 0) {
+                delete partner.assessments;
+              } else {
+                partner.assessments = partner.assessments.map((a) => {
+                  return Object.assign({}, a, {report: a.report_attachment, report_attachment: null});
+                });
+              }
+            }
+
+            // let withUpload = false; // used to set multipart prop on etools-ajax
             // if (partner.hasOwnProperty('core_values_assessments')) {
             //   if (partner.core_values_assessments.length) {
             //     for(let i = 0; i < partner.core_values_assessments.length; i++) {
@@ -268,18 +282,18 @@
             //     }
             //   }
             // }
-            if (partner.hasOwnProperty('assessments')) {
-              if ((Array.isArray(partner.assessments)) && (partner.assessments.length > 0)) {
-                partner.assessments = partner.assessments.map(function(assessment) {
-                  if (assessment.report instanceof File) {
-                    withUpload = true;
-                  } else {
-                    delete assessment.report;
-                  }
-                  return assessment;
-                }, this);
-              }
-            }
+            // if (partner.hasOwnProperty('assessments')) {
+            //   if ((Array.isArray(partner.assessments)) && (partner.assessments.length > 0)) {
+            //     partner.assessments = partner.assessments.map(function(assessment) {
+            //       if (assessment.report instanceof File) {
+            //         withUpload = true;
+            //       } else {
+            //         delete assessment.report;
+            //       }
+            //       return assessment;
+            //     }, this);
+            //   }
+            // }
             this.fireEvent('global-loading', {
               message: 'Saving...',
               active: true,
@@ -287,8 +301,8 @@
             });
             // fire in the hole
             this._triggerPartnerRequest({
-              method: 'PATCH', endpoint: endpoint, body: partner,
-              multiPart: withUpload, prepareMultipartData: withUpload
+              method: 'PATCH', endpoint: endpoint, body: partner
+              // multiPart: withUpload, prepareMultipartData: withUpload
             });
           } else {
             this.fireEvent('toast', {

--- a/pmp/modules/app-modules/partners/pages/details/components/edit-core-values-assessment.html
+++ b/pmp/modules/app-modules/partners/pages/details/components/edit-core-values-assessment.html
@@ -5,6 +5,7 @@
 
 <link rel="import" href="../../../../../layout/components/etools-form-element-wrapper.html">
 <link rel="import" href="../../../../../mixins/event-helper-mixin.html">
+<link rel="import" href="../../../../../endpoints/endpoints.html">
 <link rel="import" href="../../../../../mixins/common-mixin.html">
 <link rel="import" href="../../../../../mixins/event-helper-mixin.html">
 <link rel="import" href="../../../../../styles/required-field-styles.html">

--- a/pmp/modules/app-modules/partners/pages/financial-assurance/components/assessments-items.html
+++ b/pmp/modules/app-modules/partners/pages/financial-assurance/components/assessments-items.html
@@ -124,15 +124,6 @@
                              required
                              error-message="Please select the report file">
               </etools-upload>
-              <!--<etools-single-file-->
-                  <!--id$="report_[[index]]"-->
-                  <!--label="Report"-->
-                  <!--file="{{item.report}}"-->
-                  <!--internal-file="{{item.report_file}}"-->
-                  <!--hide-delete-btn="[[_hideDeleteBtn(item.report_file, item.report)]]"-->
-                  <!--readonly="[[!editMode]]"-->
-                  <!--accept=".doc,.docx,.pdf,.jpg,.png"-->
-                  <!--error-message="Please select the report file"></etools-single-file>-->
             </div>
           </div>
         </div>

--- a/pmp/modules/app-modules/partners/pages/financial-assurance/components/assessments-items.html
+++ b/pmp/modules/app-modules/partners/pages/financial-assurance/components/assessments-items.html
@@ -9,7 +9,7 @@
 <link rel="import" href="../../../../../../../bower_components/etools-upload/etools-upload.html">
 
 <link rel="import" href="../../../../../layout/components/etools-date-input.html">
-
+<link rel="import" href="../../../../../endpoints/endpoints.html">
 <link rel="import" href="../../../../../redux/etools-data-redux-store.html">
 <link rel="import" href="../../../../../mixins/repeatable-data-sets-mixin.html">
 

--- a/pmp/modules/app-modules/partners/pages/financial-assurance/components/assessments-items.html
+++ b/pmp/modules/app-modules/partners/pages/financial-assurance/components/assessments-items.html
@@ -6,9 +6,9 @@
 <link rel="import" href="../../../../../../../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../../../../../../../bower_components/etools-dropdown/etools-dropdown.html">
 <link rel="import" href="../../../../../../../bower_components/etools-behaviors/etools-mixin-factory.html">
+<link rel="import" href="../../../../../../../bower_components/etools-upload/etools-upload.html">
 
 <link rel="import" href="../../../../../layout/components/etools-date-input.html">
-<link rel="import" href="../../../../../layout/components/etools-single-file.html">
 
 <link rel="import" href="../../../../../redux/etools-data-redux-store.html">
 <link rel="import" href="../../../../../mixins/repeatable-data-sets-mixin.html">
@@ -47,10 +47,6 @@
 
       .add-btn-lm {
         margin-left: 46px;
-      }
-
-      etools-single-file {
-        width: 100%;
       }
 
       .row-h.file-container {
@@ -117,15 +113,26 @@
             </div>
             <div class="row-h file-container">
               <!-- Report file -->
-              <etools-single-file
-                  id$="report_[[index]]"
-                  label="Report"
-                  file="{{item.report}}"
-                  internal-file="{{item.report_file}}"
-                  hide-delete-btn="[[_hideDeleteBtn(item.report_file, item.report)]]"
-                  readonly="[[!editMode]]"
-                  accept=".doc,.docx,.pdf,.jpg,.png"
-                  error-message="Please select the report file"></etools-single-file>
+              <etools-upload id$="report_[[index]]"
+                             label="Report"
+                             accept=".doc,.docx,.pdf,.jpg,.png"
+                             data-args-index$="[[index]]"
+                             file-url="[[item.report_attachment]]"
+                             upload-endpoint="[[uploadEndpoint]]"
+                             on-upload-finished="_uploadFinished"
+                             readonly="[[!editMode]]"
+                             required
+                             error-message="Please select the report file">
+              </etools-upload>
+              <!--<etools-single-file-->
+                  <!--id$="report_[[index]]"-->
+                  <!--label="Report"-->
+                  <!--file="{{item.report}}"-->
+                  <!--internal-file="{{item.report_file}}"-->
+                  <!--hide-delete-btn="[[_hideDeleteBtn(item.report_file, item.report)]]"-->
+                  <!--readonly="[[!editMode]]"-->
+                  <!--accept=".doc,.docx,.pdf,.jpg,.png"-->
+                  <!--error-message="Please select the report file"></etools-single-file>-->
             </div>
           </div>
         </div>
@@ -186,6 +193,12 @@
           assessmentTypes: {
             type: Array,
             statePath: 'assessmentTypes'
+          },
+          uploadEndpoint: {
+            type: String,
+            value: function() {
+              return EtoolsPmpApp.Endpoints.attachmentsUpload.url;
+            }
           }
         };
       }
@@ -204,17 +217,12 @@
           type: null,
           completed_date: null,
           current: false,
-          report: null,
-          report_file: ''
+          report_attachment: null
         };
       }
 
       _editModeChanged() {
         this.updateStyles();
-      }
-
-      _hideDeleteBtn(itemReportFile) {
-        return !!itemReportFile;
       }
 
       _assessmentPropertyChanged(dataPath) {
@@ -236,26 +244,22 @@
         let valid = true;
         switch (field) {
           case 'assessmentType':
-            if (_.isEmpty(type) && (!_.isEmpty(completedDate) || this._hasReport(reportFile, reportFileLength))) {
+            if (_.isEmpty(type) && (!_.isEmpty(completedDate) || reportFile)) {
               valid = false;
             }
             break;
           case 'dateSubmitted':
-            if (_.isEmpty(completedDate) && (!_.isEmpty(type) || this._hasReport(reportFile, reportFileLength))) {
+            if (_.isEmpty(completedDate) && (!_.isEmpty(type) || reportFile)) {
               valid = false;
             }
             break;
           case 'report':
-            if (!this._hasReport(reportFile, reportFileLength) && (!_.isEmpty(type) || !_.isEmpty(completedDate))) {
+            if (!reportFile && (!_.isEmpty(type) || !_.isEmpty(completedDate))) {
               valid = false;
             }
             break;
         }
         return valid;
-      }
-
-      _hasReport(report, reportFileLength) {
-        return report instanceof File || reportFileLength > 0;
       }
 
       _addNewAssessment() {
@@ -289,15 +293,15 @@
           let fieldEl = this.shadowRoot.querySelector(fieldSelector);
           let reportFileLength = 0;
 
-          if (typeof this.dataItems[index].report_file === 'string') {
-            reportFileLength = this.dataItems[index].report_file.length;
+          if (typeof this.dataItems[index].report_attachment === 'string') {
+            reportFileLength = this.dataItems[index].report_attachment.length;
           }
           if (fieldEl) {
             let fieldName = this._getFieldNameFromSelector(fieldSelector);
             let validField = this._isValid(fieldName,
                 this.dataItems[index].type,
                 this.dataItems[index].completed_date,
-                this.dataItems[index].report,
+                this.dataItems[index].report_attachment,
                 reportFileLength, fieldEl);
             fieldEl.invalid = !validField;
             if (!validField) {
@@ -312,8 +316,7 @@
       _emptyAssessment(assessment) {
         return assessment && !assessment.type &&
             assessment.completed_date === null &&
-            assessment.report_file.length === 0 &&
-            assessment.report instanceof File === false;
+            !assessment.report_attachment;
       }
 
       _getFieldNameFromSelector(fieldSelector) {
@@ -325,6 +328,14 @@
 
       _getAddBtnAdditionalClass(shownAssessmentsNumber) {
         return shownAssessmentsNumber ? 'add-btn-lm' : '';
+      }
+
+      _uploadFinished(e) {
+        if (e.detail.success) {
+          const assessmentIndex = Number(e.target.getAttribute('data-args-index'));
+          const uploadResponse = JSON.parse(e.detail.success);
+          this.set(['dataItems', assessmentIndex, 'report_attachment'], uploadResponse.id);
+        }
       }
 
     }

--- a/pmp/modules/app-modules/partners/pages/financial-assurance/partner-financial-assurance.html
+++ b/pmp/modules/app-modules/partners/pages/financial-assurance/partner-financial-assurance.html
@@ -14,8 +14,6 @@
 <link rel="import" href="../../../../../../bower_components/etools-behaviors/etools-mixin-factory.html">
 <link rel="import" href="../../../../../../bower_components/etools-dropdown/etools-dropdown.html">
 
-<link rel="import" href="../../../../layout/components/etools-single-file.html">
-
 <link rel="import" href="../../../../endpoints/endpoints-mixin.html"/>
 <link rel="import" href="../../../../config/config.html"/>
 <link rel="import" href="../../../../mixins/ajax-server-errors-mixin.html">

--- a/pmp/modules/app-modules/partners/partners-module.html
+++ b/pmp/modules/app-modules/partners/partners-module.html
@@ -466,7 +466,7 @@
         let changes = {};
         updatableFields.forEach((fieldName) => {
           // TODO: improve this
-          if (['shared_with', 'assessments', 'staff_members'].indexOf(fieldName) > -1) {
+          if (['shared_with', 'assessments', 'staff_members', 'planned_engagement'].indexOf(fieldName) > -1) {
             if (JSON.stringify(partner[fieldName]) !== JSON.stringify(this.originalPartnerData[fieldName])) {
               if (fieldName === 'assessments') {
                 changes[fieldName] = partner[fieldName].filter(

--- a/pmp/modules/app-modules/partners/partners-module.html
+++ b/pmp/modules/app-modules/partners/partners-module.html
@@ -460,28 +460,37 @@
           'shared_with',
           'staff_members',
           'assessments',
-          'core_values_assessment',
           'planned_engagement',
           'basis_for_risk_rating'
         ];
         let changes = {};
-        updatableFields.forEach(function(fieldName) {
+        updatableFields.forEach((fieldName) => {
           // TODO: improve this
           if (['shared_with', 'assessments', 'staff_members'].indexOf(fieldName) > -1) {
             if (JSON.stringify(partner[fieldName]) !== JSON.stringify(this.originalPartnerData[fieldName])) {
-              changes[fieldName] = partner[fieldName];
-            }
-          } else if (fieldName === 'core_values_assessment') {
-            if ((partner.hasOwnProperty('core_values_assessment')) &&
-                (partner.core_values_assessment instanceof File)) {
-              changes.core_values_assessment = partner.core_values_assessment;
+              if (fieldName === 'assessments') {
+                changes[fieldName] = partner[fieldName].filter(
+                    a => typeof a.report_attachment === 'number' && a.report_attachment > 0);
+                if (partner[fieldName].length === 0) {
+                  delete partner[fieldName];
+                } else {
+                  partner[fieldName] = partner[fieldName].map((a) => {
+                    // TODO: remove this once old upload properties are removed from backend
+                    delete a.report;
+                    delete a.report_file;
+                    return a;
+                  });
+                }
+              } else {
+                changes[fieldName] = partner[fieldName];
+              }
             }
           } else {
             if (partner[fieldName] !== this.originalPartnerData[fieldName]) {
               changes[fieldName] = partner[fieldName];
             }
           }
-        }.bind(this));
+        });
         return changes;
       }
 


### PR DESCRIPTION
[ch6586] - partner assessments attachments using new upload functionality
BE is not working:
* if I use `assessment.report` property I get the error:
```
report: ["The submitted data was not a file. Check the encoding type on the form."]
```
* but we should not use `assessment.report` and use instead `assessment.report_attachment` to keep consistency