### PR TITLE
fix update path method to avoid triggering route change events twice

### DIFF
--- a/pmp/app-shell.html
+++ b/pmp/app-shell.html
@@ -402,8 +402,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       _updatePath(path) {
-        this.set('route.__queryParams', null);
-        this.set('route.path', this.rootPath + path);
+        this.setProperties({
+          'route.path': this.rootPath + path,
+          'route.__queryParams': null
+        });
       }
 
       _pageNotFound() {


### PR DESCRIPTION
[ch8362] [ch8432] - fix issue: `from reports list open reset data dialog and select "Agreements". Result: data is refreshed but the page remains in loading and is displaying only reports list title even the url is for agreements list page` 