### PR TITLE
[ch18523] Progress bar percentage number should go beyond 100%, the bar color should be filled 100%

### DIFF
--- a/src_ts/components/layout/etools-progress-bar.ts
+++ b/src_ts/components/layout/etools-progress-bar.ts
@@ -82,7 +82,7 @@ class EtoolsProgressBar extends PolymerElement {
     if (isNaN(value)) {
       return 0;
     }
-    value = (value > 100) ? 100 : value; // cannot be bigger than 100
+    // value = (value > 100) ? 100 : value; // cannot be bigger than 100
     value = (value < 0) ? 0 : value; // cannot be less that 0
 
     this.updateStyles({'--etools-progress-width-on-print': value + '%'});


### PR DESCRIPTION
[ch18523] Progress bar percentage number should go beyond 100%, the bar color should be filled 100%