### PR TITLE
[ch20798] Global Save btn from Attachments tab, for Ended PD is not needed anymore

### DIFF
--- a/src_ts/components/app-modules/interventions/components/intervention-status.ts
+++ b/src_ts/components/app-modules/interventions/components/intervention-status.ts
@@ -209,9 +209,6 @@ class InterventionStatus extends EtoolsStatusCommonMixin(PolymerElement) {
         break;
 
       case CONSTANTS.STATUSES.Ended.toLowerCase():
-        if (this.activeTab === 'attachments') {
-          availableOptions.push('Save');
-        }
         break;
 
         // legacy version of 'ended'


### PR DESCRIPTION
[ch20798] Global Save btn from Attachments tab, for Ended PD is not needed anymore