### PR TITLE
[ch20798] Global Save btn from Attachments tab, for Ended and Closed PD is not needed anymore

### DIFF
--- a/src_ts/components/app-modules/interventions/components/intervention-status.ts
+++ b/src_ts/components/app-modules/interventions/components/intervention-status.ts
@@ -203,9 +203,6 @@ class InterventionStatus extends EtoolsStatusCommonMixin(PolymerElement) {
         break;
 
       case CONSTANTS.STATUSES.Closed.toLowerCase():
-        if (this.activeTab === 'attachments') {
-          availableOptions.push('Save');
-        }
         break;
 
       case CONSTANTS.STATUSES.Ended.toLowerCase():


### PR DESCRIPTION
[ch20798] Global Save btn from Attachments tab, for Ended and Closed PD is not needed anymore