### PR TITLE
 [ch32097] Countries dropdown doesn't go to item that starts with the pressed letter

### DIFF
--- a/src_ts/components/app-shell/header/countries-dropdown.ts
+++ b/src_ts/components/app-shell/header/countries-dropdown.ts
@@ -86,7 +86,7 @@ class CountriesDropdown extends connect(store)(EtoolsPageRefreshMixinLit(Endpoin
         option-value="id"
         trigger-value-change-event
         @etools-selected-item-changed="${this._countrySelected}"
-        shown-options-limit="250"
+        .shownOptionsLimit="${250}"
         hide-search
         auto-width
       ></etools-dropdown>


### PR DESCRIPTION
 [ch32097] Countries dropdown doesn't go to item that starts with the pressed letter